### PR TITLE
Add initial naming-conventions.md file

### DIFF
--- a/naming-conventions.md
+++ b/naming-conventions.md
@@ -42,9 +42,10 @@ foldr :: Foldable t => (a -> b -> b) -> b -> t a -> b
 traverse :: (Applicative f, Traversable t) => (a -> f b) -> t a -> f (t b)
 ```
 
-`m` is always always `Monad`
+`m` is almost always `Monad` or something monad-transformer related
 ```haskell
 when :: Monad m => Bool -> m () -> m ()
+liftIO :: MonadIO m => IO a -> m a
 ```
 
 `s` is for state and `e` is for environment
@@ -57,7 +58,7 @@ These are conventions only, but picking something unusual for a common typeclass
 
 ### Concrete Types
 
-Avoid using single-letter names or abbreviations for values with a concrete type, especially if that type is domain-specific.
+Avoid using single-letter names or abbreviations for values with a concrete type, especially if that type is domain-specific. To crib from the [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/#fundamentals), "Clarity is more important than brevity."
 
 For example, don't do this:
 ```haskell 
@@ -91,7 +92,7 @@ fetchCourseMemberships (Entity teacherId teacher) =
     pure memberships
 ```
 
-One abbreviation we seem to tolerate is `num` as in `numQuestionsAnswered`. There may be others.
+We tolerate a few abbreviations as part of identifiers (e.g. the `num` portion of `numQuestionsAnswered`), but there doesn't seem to be any broad consensnus about this.
 
 ## JavaScript
 

--- a/naming-conventions.md
+++ b/naming-conventions.md
@@ -92,7 +92,7 @@ fetchCourseMemberships (Entity teacherId teacher) =
     pure memberships
 ```
 
-We tolerate a few abbreviations as part of identifiers (e.g. the `num` portion of `numQuestionsAnswered`), but there doesn't seem to be any broad consensnus about this.
+We tolerate a few abbreviations as components of identifiers (e.g. the `num` portion of `numQuestionsAnswered`), but there doesn't seem to be any broad consensus about this.
 
 ## JavaScript
 

--- a/naming-conventions.md
+++ b/naming-conventions.md
@@ -2,23 +2,32 @@
 
 ## Postgres
 
-Postgres uses `snake_case`. Tables should be plural (e.g. `teachers`, `students`). Text-based enums are currently also `snake_case` (except domain abbreviations and math system which are `ALLCAPS`), though this makes interoperating with Haskell and JavaScript non-obvious.
+Postgres uses `snake_case`. Tables should be plural (e.g. `teachers`,
+`students`). Text-based enums are currently also `snake_case` (except domain
+abbreviations and math system which are `ALLCAPS`), though this makes
+interoperating with Haskell and JavaScript non-obvious.
 
 ## Haskell
 
-Haskell uses `camelCase` for identifiers and `TitleCase` for types and constructors. The latter is enforced by the language. Names that are being ignored should either use the wildcard `_` or specify what is being ignored (e.g. `_teacher`, `_standard`).
+Haskell uses `camelCase` for identifiers and `TitleCase` for types and
+constructors. The latter is enforced by the language. Names that are being
+ignored should either use the wildcard `_` or specify what is being ignored
+(e.g. `_teacher`, `_standard`).
 
 ### Polymorphic Types
 
-Prefer short, single-letter names for polymorphic type variables and arguments. You'll notice a number of conventions with type variables.
+Prefer short, single-letter names for polymorphic type variables and arguments.
+You'll notice a number of conventions with type variables.
 
 Unconstrained type variables often start with `a` and continue alphabetically
+
 ```haskell
 id :: a -> a
 const :: a -> b -> a
 ```
 
 Polymorphic lists are often "pluralized" by appending `s`
+
 ```haskell
 filter :: (a -> Bool) -> [a] -> [a]
 filter _ [] = []
@@ -30,6 +39,7 @@ filter predicate (a:as)
 ```
 
 `f` is for `Functor` and sometimes `Applicative` and `Alternative`
+
 ```haskell
 fmap :: Functor f => (a -> b) -> f a -> f b
 liftA2 :: Applicative f => (a -> b -> c) -> f a -> f b -> f c
@@ -37,31 +47,39 @@ guard :: Alternative f => Bool -> f ()
 ```
 
 `t` might be `Traversable` or `Foldable`
+
 ```haskell
 foldr :: Foldable t => (a -> b -> b) -> b -> t a -> b
 traverse :: (Applicative f, Traversable t) => (a -> f b) -> t a -> f (t b)
 ```
 
 `m` is almost always `Monad` or something monad-transformer related
+
 ```haskell
 when :: Monad m => Bool -> m () -> m ()
 liftIO :: MonadIO m => IO a -> m a
 ```
 
 `s` is for state and `e` is for environment
+
 ```haskell
 put :: MonadState s m => s -> m ()
 ask :: MonadReader e m => m e
 ```
 
-These are conventions only, but picking something unusual for a common typeclass might surprise other readers.
+These are conventions only, but picking something unusual for a common typeclass
+might surprise other readers.
 
 ### Concrete Types
 
-Avoid using single-letter names or abbreviations for values with a concrete type, especially if that type is domain-specific. To crib from the [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/#fundamentals), "Clarity is more important than brevity."
+Avoid using single-letter names or abbreviations for values with a concrete
+type, especially if that type is domain-specific. To crib from the
+[Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/#fundamentals),
+"Clarity is more important than brevity."
 
 For example, don't do this:
-```haskell 
+
+```haskell
 fetchCourseMemberships :: MonadIO m => Entity Teacher -> SqlReadT m [Entity CourseMembership]
 fetchCourseMemberships (Entity tId teacher) =
   select $ from $ \(ts `InnerJoin` cs `InnerJoin` cms) -> do
@@ -77,6 +95,7 @@ fetchCourseMemberships (Entity tId teacher) =
 ```
 
 Do this instead:
+
 ```haskell
 fetchCourseMemberships :: MonadIO m => Entity Teacher -> SqlReadT m [Entity CourseMembership]
 fetchCourseMemberships (Entity teacherId teacher) =
@@ -92,19 +111,32 @@ fetchCourseMemberships (Entity teacherId teacher) =
     pure memberships
 ```
 
-We tolerate a few abbreviations as components of identifiers (e.g. the `num` portion of `numQuestionsAnswered`), but there doesn't seem to be any broad consensus about this.
+We tolerate a few abbreviations as components of identifiers (e.g. the `num`
+portion of `numQuestionsAnswered`), but there doesn't seem to be any broad
+consensus about this.
 
 ## JavaScript
 
-JavaScript uses `camelCase` for identifiers and `TitleCase` for classes and React components. For flow types, we generally append a `T` to the end of the type, e.g. `SkillT`. Names that are being ignored should be prefixed with an underscore (e.g. `_teacher`, `_standard`). It's a common mistake (especially for Haskellers) to use a lone `_` and accidentally overwrite underscore in that scope.
+JavaScript uses `camelCase` for identifiers and `TitleCase` for classes and
+React components. For flow types, we generally append a `T` to the end of the
+type, e.g. `SkillT`. Names that are being ignored should be prefixed with an
+underscore (e.g. `_teacher`, `_standard`). It's a common mistake (especially for
+Haskellers) to use a lone `_` and accidentally overwrite underscore in that
+scope.
 
 ## {DRAFT} Interoperation Between Languages
 
-JSON keys should always be `camelCase`. String enums that cross language barriers should be `snake_case`, since most enums that cross language barriers are designed for `postgres` first. Exceptions can be made for short initialisms which may be `ALLCAPS` (e.g. `TEKS: MathSystemT`). Short initialisms that are part of other identifiers should use `snake_case` (e.g. `rti_coordinator: TeacherRoleT`).
+JSON keys should always be `camelCase`. String enums that cross language
+barriers should be `snake_case`, since most enums that cross language barriers
+are designed for `postgres` first. Exceptions can be made for short initialisms
+which may be `ALLCAPS` (e.g. `TEKS: MathSystemT`). Short initialisms that are
+part of other identifiers should use `snake_case`
+(e.g. `rti_coordinator: TeacherRoleT`).
 
 ### Generating Enums from Haskell for Postgres
 
 Snake-case enum
+
 ```haskell
 data TeacherRole
   = Teacher
@@ -121,6 +153,7 @@ mkPersistEnum ''TeacherRole
 ```
 
 All-caps enum
+
 ```haskell
 data MathSystem
   = CCSS  -- Common Core Standard System
@@ -136,6 +169,7 @@ mkPersistEnumUsing id ''MathSystem
 ### Generating Enums from Haskell for JavaScript
 
 Snake-case enum
+
 ```haskell
 data TeacherRole
   = Teacher
@@ -152,6 +186,7 @@ deriveJSONEnum ''TeacherRole
 ```
 
 All-caps enum
+
 ```haskell
 data MathSystem
   = CCSS  -- Common Core Standard System
@@ -168,6 +203,7 @@ deriveJSONEnumUsing id ''MathSystem
 ### Enums in JavaScript
 
 JavaScript enums should be typed using `flow`, e.g.:
+
 ```jsx
 type TeacherRoleT
   = 'teacher'
@@ -175,7 +211,9 @@ type TeacherRoleT
   | ...
 ```
 
-One is encouraged to make smart constructors for enums to reduce the risk of misspellings. `flow` usually catches misspellings, but not always.
+One is encouraged to make smart constructors for enums to reduce the risk of
+misspellings. `flow` usually catches misspellings, but not always.
+
 ```jsx
 const TeacherRoles = {
   Teacher: ('teacher': TeacherRoleT),

--- a/naming-conventions.md
+++ b/naming-conventions.md
@@ -1,0 +1,106 @@
+# Naming Conventions
+
+## Postgres
+
+Postgres uses `snake_case`. Tables should be plural (e.g. `teachers`, `students`). Text-based enums are currently also `snake_case` (except domain abbreviations and math system which are `ALLCAPS`), though this makes interoperating with Haskell and JavaScript non-obvious.
+
+## Haskell
+
+Haskell uses `camelCase` for identifiers and `TitleCase` for types and constructors. The latter is enforced by the language. Names that are being ignored should either use the wildcard `_` or specify what is being ignored (e.g. `_teacher`, `_standard`).
+
+### Polymorphic Types
+
+Prefer short, single-letter names for polymorphic type variables and arguments. You'll notice a number of conventions with type variables.
+
+Unconstrained type variables often start with `a` and continue alphabetically
+```haskell
+id :: a -> a
+const :: a -> b -> a
+```
+
+Polymorphic lists are often "pluralized" by appending `s`
+```haskell
+filter :: (a -> Bool) -> [a] -> [a]
+filter _ [] = []
+filter predicate (a:as)
+  | predicate a = a : bs
+  | otherwise = bs
+ where
+  bs = filter predicate as
+```
+
+`f` is for `Functor` and sometimes `Applicative` and `Alternative`
+```haskell
+fmap :: Functor f => (a -> b) -> f a -> f b
+liftA2 :: Applicative f => (a -> b -> c) -> f a -> f b -> f c
+guard :: Alternative f => Bool -> f ()
+```
+
+`t` might be `Traversable` or `Foldable`
+```haskell
+foldr :: Foldable t => (a -> b -> b) -> b -> t a -> b
+traverse :: (Applicative f, Traversable t) => (a -> f b) -> t a -> f (t b)
+```
+
+`m` is always always `Monad`
+```haskell
+when :: Monad m => Bool -> m () -> m ()
+```
+
+`s` is for state and `e` is for environment
+```haskell
+put :: MonadState s m => s -> m ()
+ask :: MonadReader e m => m e
+```
+
+These are conventions only, but picking something unusual for a common typeclass might surprise other readers.
+
+### Concrete Types
+
+Avoid using single-letter names or abbreviations for values with a concrete type, especially if that type is domain-specific.
+
+For example, don't do this:
+```haskell 
+fetchCourseMemberships :: MonadIO m => Entity Teacher -> SqlReadT m [Entity CourseMembership]
+fetchCourseMemberships (Entity tId teacher) =
+  select $ from $ \(ts `InnerJoin` cs `InnerJoin` cms) -> do
+    on $ cs ^. CourseId ==. cms  ^. CourseMembershipCourseId
+    on $ cs ^. CourseTeacherId ==. ts ^. TeacherId
+    where_ $
+      case teacherSchoolId teacher of
+        Just sId ->
+          ts ^. TeacherSchoolId ==. val (Just sId)
+        Nothing ->
+          ts ^. TeacherId ==. val tId
+    pure cms
+```
+
+Do this instead:
+```haskell
+fetchCourseMemberships :: MonadIO m => Entity Teacher -> SqlReadT m [Entity CourseMembership]
+fetchCourseMemberships (Entity teacherId teacher) =
+  select $ from $ \(teachers `InnerJoin` courses `InnerJoin` memberships) -> do
+    on $ courses ^. CourseId ==. memberships  ^. CourseMembershipCourseId
+    on $ courses ^. CourseTeacherId ==. teachers ^. TeacherId
+    where_ $
+      case teacherSchoolId teacher of
+        Just schoolId ->
+          teachers ^. TeacherSchoolId ==. val (Just schoolId)
+        Nothing ->
+          teachers ^. TeacherId ==. val teacherId
+    pure memberships
+```
+
+One abbreviation we seem to tolerate is `num` as in `numQuestionsAnswered`. There may be others.
+
+## JavaScript
+
+JavaScript uses `camelCase` for identifiers and `TitleCase` for classes and React components. For flow types, we generally append a `T` to the end of the type, e.g. `SkillT`. Names that are being ignored should be prefixed with an underscore (e.g. `_teacher`, `_standard`). It's a common mistake (especially for Haskellers) to use a lone `_` and accidentally overwrite underscore in that scope.
+
+## Problems
+
+Serialization of string-enums to JSON and postgres is all over the place. We have examples of `snake_case`, `camelCase`, `TitleCase`, and `ALLCAPS`.
+
+If we have DB-level enums that are not shared with the frontend, it makes sense to use the postgres convention of `snake_case`. However, if we're planning to pass enums to the frontend, then we should use whatever the JavaScript convention is. JavaScript is also using pretty much everything, so it's hard to say what we should be using. I (Parks) usually use `TitleCase` for JavaScript-only enums, but only because that mimics Haskell enums.
+
+Haskell pretty much enforces a style at the language-level by requiring that the first character of each constructor be capitalized. We're using `TitleCase` everywhere except for `MathSystem` and `DomainAbbreviation` which are `ALLCAPS`.


### PR DESCRIPTION
I'm adding this here instead of the wiki, but I'll probably link from there eventually.

Most of this is uncontroversial, but the thing we should discuss is the `Problems` section. From looking at our codebase, one might infer the following styles for enums:
1. Haskell - `TitleCase` and (rarely) `ALLCAPS`
2. Postgres - `snake_case` and `ALLCAPS`
3. JavaScript - `snake_case`, `TitleCase`, `camelCase`, `ALLCAPS`
4. YAML - `snake_case`, `hyphen-case`, `TitleCase`, `Title_Snake_Case` (?!)

Sometimes we translate `snake_case` enums into `TitleCase` or `camelCase` for the frontend, but we're definitely not doing it consistently.

Part of the problem is that we sometimes use the `To/FromJSON` instances to serialize enums to postgres, which means _there can only be one_ serialization method, and it usually fits the postgres convention. We also have some library functions `deriveJSONEnum[Using]` that seem to indicate at one point we did want to surface `snake_case` enums to the frontend.

**tldr;** it's more complicated than we thought. Plz discuss. Plz halp.