### PR TITLE
Derive all the things

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -593,7 +593,14 @@ module Driver
   ```yaml
   default-extensions:
     - BangPatterns
+    - DeriveAnyClass
+    - DeriveFoldable
+    - DeriveFunctor
     - DeriveGeneric
+    - DeriveLift
+    - DeriveTraversable
+    - DerivingStrategies
+    - GeneralizedNewtypeDeriving
     - LambdaCase
     - NoImplicitPrelude
     - NoMonomorphismRestriction
@@ -601,6 +608,7 @@ module Driver
     - RankNTypes
     - RecordWildCards
     - ScopedTypeVariables
+    - StandaloneDeriving
     - TypeApplications
     - TypeFamilies
   ```


### PR DESCRIPTION
Extend the list of default extensions to include the full suite of deriving extensions. We want making types to be cheap and for types to be usable they often need to derive helpful typeclasses. By turning on the full suite of derivation extensions we make deriving cheaper and thus new types cheaper.