### PR TITLE
Add common extensions to default-extensions

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -600,8 +600,12 @@ module Driver
     - DeriveLift
     - DeriveTraversable
     - DerivingStrategies
+    - FlexibleContexts
+    - FlexibleInstances
+    - GADTs
     - GeneralizedNewtypeDeriving
     - LambdaCase
+    - MultiParamTypeClasses
     - NoImplicitPrelude
     - NoMonomorphismRestriction
     - OverloadedStrings


### PR DESCRIPTION
The following extensions should be in our default extensions. They are used pretty pervasively and they have no ill effects. None of these extensions increase or modify compilation times. They do not have ill effects on type inference. They just unlock abilities that we use in many places.

This WIP PR displays the need: https://github.com/frontrowed/megarepo/pull/3817