### PR TITLE
Specify naming guide for request/response types.

### DIFF
--- a/naming-conventions.md
+++ b/naming-conventions.md
@@ -229,8 +229,8 @@ This will produce the following JSON:
 ### Request/Response types
 
 For complicated `Handler` requests or responses, where we use a custom type
-instead of domain object, such types should be named `{Resource}{Method}` where
-`Resource` matches the route and `Method` is Sentence-case.
+instead of a domain object, such types should be named `{Resource}{Method}`
+where `Resource` matches the route and `Method` is Sentence-case.
 
 ```hs
 -- Good

--- a/naming-conventions.md
+++ b/naming-conventions.md
@@ -226,6 +226,53 @@ This will produce the following JSON:
 }
 ```
 
+### Request/Response types
+
+For complicated `Handler` requests or responses, where we use a custom type
+instead of an `Entity` directly, such types should be named `{Resource}{Method}`
+where `Resource` matches the route and `Method` is Sentence-case.
+
+```hs
+-- Good
+data SchoolGet
+  -- ...
+
+instance ToJSON SchoolGet where
+  -- ...
+
+getSchoolR :: SchoolId -> Handler Value
+getSchoolR schoolId = do
+  school <- get404 schoolId
+  sendStatusJSON status200 SchoolGet {- ... -}
+
+data SchoolsPost
+  -- ...
+
+instance FromJSON SchoolsPost where
+  -- ...
+
+postSchoolsR :: Handler Value
+postSchoolsR = do
+  SchoolsPost {..} <- requireJsonBody
+  -- ...
+
+-- Bad
+data GetSchool
+  -- Out of order (though gramatically attractive)
+
+data SchoolGET
+  -- Wrong case
+
+data SchoolResponse
+  -- Missing Method, redundant suffix
+
+data GetSchools
+  -- Incorrect plurization
+
+data CreateSchoolPost
+  -- Duplicate verb, incorrect pluralization
+```
+
 ## JavaScript
 
 JavaScript uses `camelCase` for identifiers and `TitleCase` for classes and

--- a/naming-conventions.md
+++ b/naming-conventions.md
@@ -229,8 +229,8 @@ This will produce the following JSON:
 ### Request/Response types
 
 For complicated `Handler` requests or responses, where we use a custom type
-instead of an `Entity` directly, such types should be named `{Resource}{Method}`
-where `Resource` matches the route and `Method` is Sentence-case.
+instead of domain object, such types should be named `{Resource}{Method}` where
+`Resource` matches the route and `Method` is Sentence-case.
 
 ```hs
 -- Good


### PR DESCRIPTION
NOTE: This was an attempt to codify what we do most-commonly at this
time, not an attempt at finding an objectively good guide. If folks want
to propose an objectively good guide, have at it.

We are currently in violation of this guide because we're inconsistent
in casing the `Method` suffix, but these types are very easy to identify
and rename, so I plan to resolve things as soon as this is accepted.