### PR TITLE
Address markdownlint issues in all files

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,4 @@
+# vim: ft=ruby
+
+# Disable "Trailing punctuation in header" rule
+rules "~MD026"

--- a/fancy-terms.md
+++ b/fancy-terms.md
@@ -1,15 +1,36 @@
 # Fancy Terms
-Functional programmers borrow many terms from mathematics. These terms can cause a fair amount of anxiety for those who are not familiar. So why use them?
 
-# Why use them?
-The reason we use "fancy" terms is because they are precise. We use the word `Monoid` because it says exactly what we mean. We could say, "this type has a function that takes two arguments and produces the same type, as well that function is associative (uh oh concept), and..." You see where I'm going. Fancy terms allow us to be much more compact, they have high conceptual density and precision. This brevity allows use to communicate very complex concepts precisely and succinctly.
+Functional programmers borrow many terms from mathematics. These terms can cause
+a fair amount of anxiety for those who are not familiar. So why use them?
 
-As well as precision and brevity, fancy terms often give us access. There are combined hundreds of years of writing and research built in to these terms. They are the common language of logicians, mathemeticians, computer scientists and other academics who study complex problems. By utilizing these terms we give ourselves access to mountains of solutions to big problems. If you have a problem, it has probably already been solved or atleast researched to death by some lonely academic in a dark dusty corner speaking this foreign tongue of fancy terms.
+## Why use them?
 
-# What is the cost?
-Every choice comes with benefits and costs. The cost of fancy terms is that anyone who uses one must be prepared to explain that term. This document attempts to briefly explain some of these fancy terms and provide some reason why they are beneficial.
+The reason we use "fancy" terms is because they are precise. We use the word
+`Monoid` because it says exactly what we mean. We could say, "this type has a
+function that takes two arguments and produces the same type, as well that
+function is associative (uh oh concept), and..." You see where I'm going. Fancy
+terms allow us to be much more compact, they have high conceptual density and
+precision. This brevity allows use to communicate very complex concepts
+precisely and succinctly.
 
-# The Terms
+As well as precision and brevity, fancy terms often give us access. There are
+combined hundreds of years of writing and research built in to these terms. They
+are the common language of logicians, mathematicians, computer scientists and
+other academics who study complex problems. By utilizing these terms we give
+ourselves access to mountains of solutions to big problems. If you have a
+problem, it has probably already been solved or at least researched to death by
+some lonely academic in a dark dusty corner speaking this foreign tongue of
+fancy terms.
+
+## What is the cost?
+
+Every choice comes with benefits and costs. The cost of fancy terms is that
+anyone who uses one must be prepared to explain that term. This document
+attempts to briefly explain some of these fancy terms and provide some reason
+why they are beneficial.
+
+## The Terms
+
 * [arrow](#arrow)
 * [morphism](#morphism)
 * [object](#object)
@@ -20,29 +41,80 @@ Every choice comes with benefits and costs. The cost of fancy terms is that anyo
 * [bijective](#bijective)
 * [isomorphism](#isomorphism)
 
-## arrow
-Functional programmers sometimes talk about an arrow from `A` to `B`. There is a typeclass `Arrow`, but often we are just talking about something more abstract. We just want to say `A` is conceptually linked to `B` in a specific direction. An arrow could be a function, a process, a network transfer, a memo I wrote on a napkin; these details don't matter. All that matters is somehow we got from `A` to `B`. This conceptual brevity lets us take a step back and focus on the bigger picture. If I told you I drove a car from point `A` to `B` then you've already inferred a lot of detail that I might not have wanted to convey. Arrows let us focus less on implementation details and more on abstract attributes that we desire.
+### arrow
 
-## morphism
+Functional programmers sometimes talk about an arrow from `A` to `B`. There is a
+typeclass `Arrow`, but often we are just talking about something more abstract.
+We just want to say `A` is conceptually linked to `B` in a specific direction.
+An arrow could be a function, a process, a network transfer, a memo I wrote on a
+napkin; these details don't matter. All that matters is somehow we got from `A`
+to `B`. This conceptual brevity lets us take a step back and focus on the bigger
+picture. If I told you I drove a car from point `A` to `B` then you've already
+inferred a lot of detail that I might not have wanted to convey. Arrows let us
+focus less on implementation details and more on abstract attributes that we
+desire.
+
+### morphism
+
 This is a fancy word for arrow used in category theory.
 
-## object
-OOP has co-opted the word object, but functional programmers still use it. Objects in OOP are members of a type, that encapsulated state, and have associated methods. In functional programming we throw away the state and methods. An object in FP is just a member of a type. `1` is an object of type `Int`. `"foo"` is an object of type `String`. Often we prefer to use the word value to avoid confusion, but mathematitions still like the word object.
+### object
 
-## domain
-The left hand side of an arrow. I.E. The types of the arguments to a function. `Int` is the domain of `Int -> String`.
+OOP has co-opted the word object, but functional programmers still use it.
+Objects in OOP are members of a type, that encapsulated state, and have
+associated methods. In functional programming we throw away the state and
+methods. An object in FP is just a member of a type. `1` is an object of type
+`Int`. `"foo"` is an object of type `String`. Often we prefer to use the word
+value to avoid confusion, but mathematicians still like the word object.
 
-## codomain
-The right hand side of an arrow. I.E. The type of the result of a function. `String` is the codomain of `Int -> String`
+### domain
 
-## injective
-An injective arrow is a one to one relationship in a single direction. The arrow `A -> B` is injective if all values in `A` have an arrow to `B` and distinct values in `A` never have an arrow to the same value in `B`. This does not mean that all values in `B` have a counterpart in `A`. The function `toDecimal :: Int -> Decimal` is injective because it will always result in a distinct value for every input, but there are strictly more `Decimal`s than `Int`s so the arrow only goes in one direction. An injective relationship is important because it means that we are not losing precision, but we might lose the ability to return to the original type.
+The left hand side of an arrow. I.E. The types of the arguments to a function.
+`Int` is the domain of `Int -> String`.
 
-## surjective
-A surjection is when there is an arrow from every value in `A` to every value in `B`, but arrows may point to the same value. The function `round :: Decimal -> Int` is surjective. We can transform any `Decimal` to an `Int`, but 5.3 and 5.4 will both become 5. Surjective arrows are total, they do not include any partiality and functional programmers love that.
+### codomain
+
+The right hand side of an arrow. I.E. The type of the result of a function.
+`String` is the codomain of `Int -> String`
+
+### injective
+
+An injective arrow is a one to one relationship in a single direction. The arrow
+`A -> B` is injective if all values in `A` have an arrow to `B` and distinct
+values in `A` never have an arrow to the same value in `B`. This does not mean
+that all values in `B` have a counterpart in `A`. The function `toDecimal :: Int
+-> Decimal` is injective because it will always result in a distinct value for
+every input, but there are strictly more `Decimal`s than `Int`s so the arrow
+only goes in one direction. An injective relationship is important because it
+means that we are not losing precision, but we might lose the ability to return
+to the original type.
+
+### surjective
+
+A surjection is when there is an arrow from every value in `A` to every value in
+`B`, but arrows may point to the same value. The function `round :: Decimal ->
+Int` is surjective. We can transform any `Decimal` to an `Int`, but 5.3 and 5.4
+will both become 5. Surjective arrows are total, they do not include any
+partiality and functional programmers love that.
 
 ## bijective
-A bijection is a one to one relationship in both directions. It is when an arrow exists between `A` and `B` where all values of `A` have an arrow to a value in `B` and all distinct values in `A` point to a distinct value in `B`. With fancier terms a bijection is an arrow that is injective and surjective. The bijective arrow `A -> B` gives rise to the bijective arrow `B -> A`. This is useful because it means we can change representations without losing information. It may be more convenient to utilize `Map Int Text` because it has a richer API, but more efficient to store in a `HashMap Int Text` and since a bijection exists between them we can freely swap representations for the specific use case.
 
-## isomorphism
-Isomorphism is similar to bijection. Nearly all bijections are isomorphisms. The difference is a matter of formulation. An isomorphism has specific laws that it must satisfy. An isomorphism exists between `A` and `B` if the arrows `f :: A -> B` and `g :: B -> A` satisfy the identity law `f . g = id` and `g . f = id`. Isomorphism gives us all the same power as bijection. It is strictly weaker than equality, but when we are transforming data it is often all we care about.
+A bijection is a one to one relationship in both directions. It is when an arrow
+exists between `A` and `B` where all values of `A` have an arrow to a value in
+`B` and all distinct values in `A` point to a distinct value in `B`. With
+fancier terms a bijection is an arrow that is injective and surjective. The
+bijective arrow `A -> B` gives rise to the bijective arrow `B -> A`. This is
+useful because it means we can change representations without losing
+information. It may be more convenient to utilize `Map Int Text` because it has
+a richer API, but more efficient to store in a `HashMap Int Text` and since a
+bijection exists between them we can freely swap representations for the
+specific use case.
+
+### isomorphism
+
+Isomorphism is similar to bijection. Nearly all bijections are isomorphisms. The
+difference is a matter of formulation. An isomorphism has specific laws that it
+must satisfy. An isomorphism exists between `A` and `B` if the arrows `f :: A ->
+B` and `g :: B -> A` satisfy the identity law `f . g = id` and `g . f = id`.
+Isomorphism gives us all the same power as bijection. It is strictly weaker than
+equality, but when we are transforming data it is often all we care about.

--- a/haskell-open-source.md
+++ b/haskell-open-source.md
@@ -1,4 +1,4 @@
-## Best Practices
+# Best Practices
 
 1. If authoring a distinct package of reasonable size and generic utility,
    prefer starting a separate, public repository utilized as a Git dependency

--- a/haskell-style.md
+++ b/haskell-style.md
@@ -1,22 +1,25 @@
-# FrontRow Style Guide
+# Haskell Style
 
 Principles:
 
 * **Maximize readability**
-  * Code should be immediately readable by someone not familiar with that area. If you have to continuously refer to documentation, comments or dig into implementation to understand what's happening, the code isn't sufficiently self-descriptive and needs to be improved. When not possible, you must comment. Coding is a team sport, _always write with other developers in mind_
+  * Code should be immediately readable by someone not familiar with that area.
+    If you have to continuously refer to documentation, comments or dig into
+    implementation to understand what's happening, the code isn't sufficiently
+    self-descriptive and needs to be improved. When not possible, you must
+    comment. Coding is a team sport, _always write with other developers in
+    mind_
 * **Be aware of the context**
 * **Use your judgement**
 
-There are some hard rules, but good style is context-sensitive.
-Something that is good in preferable in one place could be bad in another.
-
-# Haskell
+There are some hard rules, but good style is context-sensitive. Something that
+is good in preferable in one place could be bad in another.
 
 ## Line Length
 
-Aim for 80 columns max. Long identifiers can sometimes make this tricky, so
-this is not a hard-and-fast rule. `brittany` should handle this formatting for
-us in most cases.
+Aim for 80 columns max. Long identifiers can sometimes make this tricky, so this
+is not a hard-and-fast rule. `brittany` should handle this formatting for us in
+most cases.
 
 ## Comments
 
@@ -24,62 +27,71 @@ Comments should follow [Haddock style](https://github.com/frontrowed/guides/blob
 
 ## Monad sequences and Haskell arrows
 
-Monadic sequences should normally go in one direction, including `<-` from do notation
+Monadic sequences should normally go in one direction, including `<-` from do
+notation
 
-bad
+```haskell
+-- Bad
+result <- m >>= return
 
-    result <- m >>= return
+-- Good
+result <- return =<< m
+```
 
-good
+That isn't to say we prefer `=<<` over `>>=`
 
-    result <- return =<< m
+```haskell
+-- Good
+result <-
+      action4
+  =<< action3
+  =<< action2
+  =<< action1
 
-That isn't to say we prever `=<<` over `>>=`
+-- Better
+result <-
+      action1
+  >>= action2
+  >>= action3
+  >>= action4
 
-good
+-- Good: this is easy to read left-to-right and scales as the lambda grows
 
-    result <-
-          action4
-      =<< action3
-      =<< action2
-      =<< action1
-
-better
-
-    result <-
-          action1
-      >>= action2
-      >>= action3
-      >>= action4
-
-good. This is easy to read left-to-right and scales as the lambda grows
-
-    m >>= (\x -> )
+m >>= (\x -> )
+```
 
 In general left bind does not scale well for inline code.
 This is ok.
 
-    (\x -> f x) =<< m
+```hs
+(\x -> f x) =<< m
+```
 
 This is bad.
 
-    (\x -> do f x
-              g x
-    ) =<< m
+```hs
+(\x -> do f x
+          g x
+) =<< m
+```
 
 The lambda should be turned into a bound function.
-
 
 ## Distinguishing function arguments
 
 Be careful of creating functions that have the same input type
 
-    f :: Int -> Int -> Int -> Int
+```hs
+f :: Int -> Int -> Int -> Int
+```
 
-This is a good time to look at using a record to name the arguments or to use newtypes around the `Int`s. Note that the fact that the output is the same type as the input is not a concern: the below is fine
+This is a good time to look at using a record to name the arguments or to use
+newtypes around the `Int`s. Note that the fact that the output is the same type
+as the input is not a concern: the below is fine
 
-    f :: Int -> Int
-
+```hs
+f :: Int -> Int
+```
 
 ## Data type declarations
 
@@ -95,18 +107,16 @@ data Student
   }
 ```
 
-
-
 ### Sum Types
 
-Something small can go on one line. The scalable way of declaring things that maintains vertical alignment properties is
+Something small can go on one line. The scalable way of declaring things that
+maintains vertical alignment properties is
 
 ``` haskell
 data TransferTo
   = TransferToTeacher (Entity Teacher)
   | TransferToEmail   Email
 ```
-
 
 ## Function Type Signatures
 
@@ -143,7 +153,6 @@ which will cause a noisy diff if we rename `GameSession` (each following line
 also needs to be indented):
 
 ```diff
-
  instance FromJSON (GameSession Never MathStandardAssignmentId) where
    parseJSON = withObject "cannot parse GameSession" $ \o ->
 -   GameSession <$> o .: "answers"
@@ -160,7 +169,6 @@ also needs to be indented):
 +                <*> o .: "sub-sub-standard-perc"
 +                <*> o .: "coins-gained"
 +                <*> pure Never
-
 ```
 
 Instead, do
@@ -250,6 +258,7 @@ generally easier to read in long functional expressions.
 ### More examples
 
 #### Data declarations
+
 ```haskell
 --- Bad
 data SomeRecord = SomeRecord { someField :: Int
@@ -278,8 +287,10 @@ data SomeSum'
 ```
 
 #### Do statements
+
 ```haskell
--- Bad - do is indented 2 spaces, so the expressions following it have to be indented 5 spaces
+-- Bad - do is indented 2 spaces, so the expressions following it have to be
+-- indented 5 spaces
 someBinding =
   do x <- getLine
      y <- getLine
@@ -293,8 +304,10 @@ someBinding' = do
 ```
 
 #### Case expressions
+
 ```haskell
--- Bad - aligning to case pushes expressions way to the left, and aligning arrows is fiddly
+-- Bad - aligning to case pushes expressions way to the left, and aligning
+-- arrows is fiddly
 someBinding mx = case mx of
                    Nothing -> 0
                    Just x  -> x
@@ -315,6 +328,7 @@ someBinding'' mx =
 ```
 
 #### Let expressions
+
 ```haskell
 -- Bad - aligning multiple let bindings like this is fiddly
 someBinding mx =
@@ -372,6 +386,7 @@ someBinding mx = f <$> mx <*> mx
 ```
 
 #### Lists and Tuples
+
 ```haskell
 -- Short lists and tuples can be placed on one line
 names = ["Joe", "Bob", "Sam"]
@@ -403,6 +418,7 @@ teacher =
 ## Imports
 
 Haskell's modules expose some variety in import style:
+
 * Open imports
 * Explicit imports
 * Exclusionary imports
@@ -410,18 +426,19 @@ Haskell's modules expose some variety in import style:
 * Aliased imports
 
 Good style prefers:
+
 * Open imports for common libraries
-  - `base`
-  - `mtl`
-  - custom preludes
+  * `base`
+  * `mtl`
+  * custom preludes
 * Explicit imports for bringing lesser known functions in to scope
 * Exclusionary imports for avoiding minor name clashes
-  - `lens`
+  * `lens`
 * Qualified imports for major name clashes
-  - `containers`
-  - `unordered-containers`
+  * `containers`
+  * `unordered-containers`
 * Aliased imports for packaging and exporting many modules in a single module.
-  - creating a custom prelude
+  * creating a custom prelude
 
 ```haskell
 -- Good
@@ -434,7 +451,8 @@ import qualified Data.Map as Map
 import qualified Data.Text as Text
 
 -- Bad
--- Overly open imports lead to increased ambiguity forcing common functions to be qualified.
+-- Overly open imports lead to increased ambiguity forcing common functions to
+-- be qualified.
 import Control.Lens
 import Control.Monad.Logger
 import Control.Monad.Trans.Reader
@@ -474,14 +492,20 @@ import System.IO
 ```
 
 ### Importing types and qualifying
-It is also common to explicitly import types from a module and also import it qualified.
+
+It is also common to explicitly import types from a module and also import it
+qualified.
+
 ```
 import Data.Map (Map)
 import qualified Data.Map as Map
 ```
 
 ### Abbreviating qualifications
-There are a number of common abbreviations that are used in the community to qualify imports.
+
+There are a number of common abbreviations that are used in the community to
+qualify imports.
+
 ```haskell
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -595,7 +619,7 @@ module Driver
 
 ## Declaring Extensions
 
-- All Haskell packages MUST use the following `default-extensions`:
+* All Haskell packages MUST use the following `default-extensions`:
 
   ```yaml
   default-extensions:
@@ -631,7 +655,7 @@ module Driver
   extensions MUST be defined via LANGUAGE pragmas in the modules where they're
   needed.
 
-- Place extensions on their own line, and sort them
+* Place extensions on their own line, and sort them
 
   ```haskell
   -- Bad
@@ -644,7 +668,7 @@ module Driver
   {-# LANGUAGE RecordWildCards #-}
   ```
 
-- Leave a blank line after the extensions list
+* Leave a blank line after the extensions list
 
   ```haskell
   {-# LANGAUGE OverloadedStrings #-}
@@ -675,8 +699,8 @@ yet requiring a certain level of coverage, but it is strongly encouraged.
 
 ### General guides
 
-- Use proper Haddock [markup][]
-- Link all identifiers, anywhere they appear
+* Use proper Haddock [markup][]
+* Link all identifiers, anywhere they appear
 
   Bad
 
@@ -697,7 +721,7 @@ yet requiring a certain level of coverage, but it is strongly encouraged.
   --
   ```
 
-- Use leading documentation (`-- |`) for top-level definitions and trailing
+* Use leading documentation (`-- |`) for top-level definitions and trailing
   documentation (`-- ^`) for record attributes and function arguments
 
   Bad
@@ -826,8 +850,8 @@ Good
 
 Bodies are optional but encouraged. When present, the following applies:
 
-- Wrap non-literal content at 80 columns (not our usual 120)
-- Surround block elements by a line of whitespace
+* Wrap non-literal content at 80 columns (not our usual 120)
+* Surround block elements by a line of whitespace
 
   Bad
 
@@ -882,7 +906,7 @@ Bodies are optional but encouraged. When present, the following applies:
   theFunction
   ```
 
-- Lists receive a hanging indent
+* Lists receive a hanging indent
 
   Bad
 
@@ -918,7 +942,7 @@ Bodies are optional but encouraged. When present, the following applies:
 
 ### Module organization
 
-- Organize your exports by logical groups or [progressive
+* Organize your exports by logical groups or [progressive
   disclosure][progressive_disclosure] and use section headings
 
   Bad
@@ -949,7 +973,7 @@ Bodies are optional but encouraged. When present, the following applies:
     )
   ```
 
-- Consider adding section documentation
+* Consider adding section documentation
 
   **NOTE**: Summary/Body rules apply!
 
@@ -974,7 +998,7 @@ Bodies are optional but encouraged. When present, the following applies:
     )
   ```
 
-- If you want to separate the definitions *in* the module, use [named
+* If you want to separate the definitions *in* the module, use [named
   chunks][chunks].
 
   ```hs

--- a/naming-conventions.md
+++ b/naming-conventions.md
@@ -18,13 +18,15 @@ Don't do this:
 ```sql
 CREATE TABLE ela_adaptive_skill_practice_paragraphs (
   id integer PRIMARY KEY NOT NULL,
-  ela_adaptive_skill_practice_content_id uuid REFERENCES ela_adaptive_skill_practice_content NOT NULL,
+  ela_adaptive_skill_practice_content_id uuid
+    REFERENCES ela_adaptive_skill_practice_content NOT NULL,
   type text NOT NULL,
   content text NOT NULL,
   caption text,
   position integer NOT NULL,
   UNIQUE (ela_adaptive_skill_practice_content_id, position),
-  CONSTRAINT valid_ela_adaptive_skill_practice_paragraph_position CHECK (position >= 0)
+  CONSTRAINT valid_ela_adaptive_skill_practice_paragraph_position
+    CHECK (position >= 0)
 );
 ```
 
@@ -33,14 +35,16 @@ Do this:
 ```diff
 CREATE TABLE ela_adaptive_skill_practice_paragraphs (
   id integer PRIMARY KEY NOT NULL,
-- ela_adaptive_skill_practice_content_id uuid REFERENCES ela_adaptive_skill_practice_content NOT NULL,
+- ela_adaptive_skill_practice_content_id uuid
+-   REFERENCES ela_adaptive_skill_practice_content NOT NULL,
 + content_id uuid REFERENCES ela_adaptive_skill_practice_content NOT NULL,
   type text NOT NULL,
   content text NOT NULL,
   caption text,
   position integer NOT NULL,
   UNIQUE (ela_adaptive_skill_practice_content_id, position),
-  CONSTRAINT valid_ela_adaptive_skill_practice_paragraph_position CHECK (position >= 0)
+  CONSTRAINT valid_ela_adaptive_skill_practice_paragraph_position
+    CHECK (position >= 0)
 );
 ```
 

--- a/shell-style.md
+++ b/shell-style.md
@@ -73,7 +73,7 @@ if you use `[[` because you want regex or glob matching in one place, don't use
    rm -rf "$dirr/bar" # typo made this rm -rf /bar
    ```
 
-2. Avoid `set -x`
+1. Avoid `set -x`
 
    This option outputs every statement before it's executed. Only use this if
    your script has no function definitions, control flow structures, or
@@ -343,5 +343,5 @@ Some alternatives:
 
 ## Additional References
 
-- http://mywiki.wooledge.org/BashFAQ
-- https://robots.thoughtbot.com/the-unix-shells-humble-if
+- [BashFAQ](http://mywiki.wooledge.org/BashFAQ)
+- [The Unix Shell's Humble If](https://robots.thoughtbot.com/the-unix-shells-humble-if)


### PR DESCRIPTION
https://github.com/markdownlint/markdownlint

This was almost entirely:

- Hard-wrapping paragraphs
- Fixing trailing whitespace
- Adding whitespace around block content (headers, code blocks)
- Fixing invalid header nesting (skipping levels, multiple H1)
- Standardizing unordered list styles
- Using non-incrementing ordered list style

And I fixed some spelling errors.

There's just one lint issue left, which is a long line in a code block
that is intentionally long to show bad style.