### PR TITLE
The deriving clause should be on a new line

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -270,7 +270,8 @@ data SomeRecord'
   = SomeRecord'
   { someField :: Int
   , someOtherField :: Double
-  } deriving (Eq, Show)
+  }
+  deriving (Eq, Show)
 
 -- Bad
 data SomeSum = FirstConstructor


### PR DESCRIPTION
@pbrisbin suggested updating our style guide with modification. What do you think?