### PR TITLE
Rewrite for automated approach

### DIFF
--- a/haskell-best-practices.md
+++ b/haskell-best-practices.md
@@ -1,5 +1,8 @@
 # Haskell practices
 
+**NOTE**: the code examples here may not follow our current style. They have not
+been maintained for that as things have evolved.
+
 ## Error throwing / exceptions
 
 * Try very hard to avoid partial functions

--- a/haskell-style.md
+++ b/haskell-style.md
@@ -1,25 +1,49 @@
 # Haskell Style
 
-Principles:
+**TL;DR**: If it can be automated, it should be automated. If the automated
+outcome has no *objective* readability problems, we should accept it.
 
-* **Maximize readability**
-  * Code should be immediately readable by someone not familiar with that area.
-    If you have to continuously refer to documentation, comments or dig into
-    implementation to understand what's happening, the code isn't sufficiently
-    self-descriptive and needs to be improved. When not possible, you must
-    comment. Coding is a team sport, _always write with other developers in
-    mind_
-* **Be aware of the context**
-* **Use your judgement**
+We use three Haskell auto-formatting tools:
 
-There are some hard rules, but good style is context-sensitive. Something that
-is good in preferable in one place could be bad in another.
+- Stylish Haskell (v0.9.2.2)
+
+  We use Stylish Haskell for `import` formatting only, because it does a better
+  job than Brittany. The only manual choice we have to make is if/how to group,
+  for which we have a simple rule you can find below.
+
+- Brittany (v0.11.0.0)
+
+  Brittany will auto-format almost all Haskell code in an automatic way. The
+  current version has some hard edges (hopefully fixed in v0.12), which lead to
+  a few valid exceptions:
+
+  - Operator-heavy expressions where it's valuable to maintain a particular
+    visual shape for readability. Examples: Esqueleto, optparse-applicative
+    parsers, or lens-constructions for Stratosphere.
+
+  - Multi-line quasi-quotes. Examples `aesonQQ`, `hamlet`, etc.
+
+  Such exceptions can be disabled by pragma. Prefer doing this, so the rest of
+  the file can still auto-format successfully.
+
+- HLint (v2.1.11)
+
+  HLint, through `apply-refact`, will auto-apply some Hints. We should accept
+  these fixes or adjust HLint's configuration to not contain the hint being
+  applied.
+
+Throughout the below guide, things we used to have a manual guide on but are now
+automated by the above tools are noted as such. This (vs just omitting them) is
+done for a few reasons:
+
+- Some choices are so core to a Style Guide, that not having them visible here
+  might give the impression we don't actually have a defined choice
+- This gives us a chance to see just how much time we've saved by automating
+  what used to be a (possibly tenuous) negotiated consensus
 
 ## Line Length
 
-Aim for 80 columns max. Long identifiers can sometimes make this tricky, so this
-is not a hard-and-fast rule. `brittany` should handle this formatting for us in
-most cases.
+**Automated**.
 
 ## Comments
 
@@ -97,326 +121,23 @@ f :: Int -> Int
 
 ### Records
 
-* comma-leading e.g.
-
-```haskell
-data Student
-  = Student
-  { firstName :: Text
-  , lastName :: Text
-  }
-```
+**Automated**.
 
 ### Sum Types
 
-Something small can go on one line. The scalable way of declaring things that
-maintains vertical alignment properties is
-
-``` haskell
-data TransferTo
-  = TransferToTeacher (Entity Teacher)
-  | TransferToEmail   Email
-```
+**Automated**.
 
 ## Function Type Signatures
 
-Signatures should lead with arrows
-
-``` haskell
-:: Esqueleto m expr backend
-=> TeacherId
--> expr (Entity Student)
--> m ()
-```
+**Automated**.
 
 ## Alignment
 
-You should never need to align to preceding text. That is, your alignment point
-should always be 3rd, 5th, 7th etc. column (because we use two spaces of
-indenting).
-
-e.g. Instead of
-
-```haskell
-instance FromJSON (GameSession Never MathStandardAssignmentId) where
-  parseJSON = withObject "cannot parse GameSession" $ \o ->
-    GameSession <$> o .: "answers"
-                <*> o .: "domain-id"
-                <*> o .: "current-standard"
-                <*> o .: "sub-standard-perc"
-                <*> o .: "sub-sub-standard-perc"
-                <*> o .: "coins-gained"
-                <*> pure Never
-```
-
-which will cause a noisy diff if we rename `GameSession` (each following line
-also needs to be indented):
-
-```diff
- instance FromJSON (GameSession Never MathStandardAssignmentId) where
-   parseJSON = withObject "cannot parse GameSession" $ \o ->
--   GameSession <$> o .: "answers"
--               <*> o .: "domain-id"
--               <*> o .: "current-standard"
--               <*> o .: "sub-standard-perc"
--               <*> o .: "sub-sub-standard-perc"
--               <*> o .: "coins-gained"
--               <*> pure Never
-+   GameSession2 <$> o .: "answers"
-+                <*> o .: "domain-id"
-+                <*> o .: "current-standard"
-+                <*> o .: "sub-standard-perc"
-+                <*> o .: "sub-sub-standard-perc"
-+                <*> o .: "coins-gained"
-+                <*> pure Never
-```
-
-Instead, do
-
-```haskell
-instance FromJSON (GameSession Never MathStandardAssignmentId) where
-  parseJSON =
-    withObject "cannot parse GameSession" $ \o ->
-      GameSession
-        <$> o .: "answers"
-        <*> o .: "domain-id"
-        <*> o .: "current-standard"
-        <*> o .: "sub-standard-perc"
-        <*> o .: "sub-sub-standard-perc"
-        <*> o .: "coins-gained"
-        <*> pure Never
-```
-
-```diff
- instance FromJSON (GameSession Never MathStandardAssignmentId) where
-   parseJSON =
-     withObject "cannot parse GameSession" $ \o ->
--      GameSession
-+      GameSession2
-         <$> o .: "answers"
-         <*> o .: "domain-id"
-         <*> o .: "current-standard"
-         <*> o .: "sub-standard-perc"
-         <*> o .: "sub-sub-standard-perc"
-         <*> o .: "coins-gained"
-         <*> pure Never
-```
-
-### Operator-first
-
-The above is an example of operator-first style. Which we use generally, as in
-the following examples:
-
-```hs
-Foo
-  <$> o .: "this"
-  <*> o .: "that"
-
-foo
-  <&> foo .~ bar
-  <.> baz .~ bat
-```
-
-```hs
-fooBlahBlahHahaBlahBlahHaLongName
-  . barBlahBlahHahaBlahLongName
-  . bazBlahBlahHahaBlahHaLongName
-  $ bat quix
-
-Nothing -> left
-  $ Text.pack "could not find parser for node \""
-  <> name
-  <> Text.pack "\" of type \""
-  <> typ
-  <> Text.pack "\" at "
-  <> file
-  <> Text.pack (": " ++ show n ++ ".")
-
-logForwarderLambda :: Text -> Resource
-logForwarderLambda envName = resource "LogForwarderLambda"
-  $ LambdaFunctionProperties
-  $ lambdaFunction
-    ( lambdaFunctionCode
-    & lfcS3Bucket ?~ "frontrow-ops"
-    & lfcS3Key ?~ "logdna-lambda.zip"
-    )
-    "logdna_cloudwatch.lambda_handler"
-    (GetAtt "LambdaRole" "Arn")
-    (Literal Python27)
-  & lfFunctionName ?~ Literal (envName <> "-log-dna-forwarder")
-  & lfEnvironment ?~
-    ( lambdaFunctionEnvironment
-    & lfeVariables ?~
-      [ ("LOGDNA_KEY", toJSON (Ref "LogDNAIngestionKey" :: Val Text))
-      ]
-    )
-```
-
-This is consistent with comma-first style for structural expressions, and is
-generally easier to read in long functional expressions.
-
-### More examples
-
-#### Data declarations
-
-```haskell
---- Bad
-data SomeRecord = SomeRecord { someField :: Int
-                             , someOtherField :: Double
-                             } deriving (Eq, Show)
-
--- Good
-data SomeRecord'
-  = SomeRecord'
-  { someField :: Int
-  , someOtherField :: Double
-  }
-  deriving (Eq, Show)
-
--- Bad
-data SomeSum = FirstConstructor
-             | SecondConstructor Int
-             | ThirdConstructor Double Text
-             deriving (Eq, Show)
-
--- Good
-data SomeSum'
-  = FirstConstructor'
-  | SecondConstructor' Int
-  | ThirdConstructor' Double Text
-  deriving (Eq, Show)
-```
-
-#### Do statements
-
-```haskell
--- Bad - do is indented 2 spaces, so the expressions following it have to be
--- indented 5 spaces
-someBinding =
-  do x <- getLine
-     y <- getLine
-     putStrLn $ x <> y
-
--- Good - do is left hanging so the bindings are just indented 2 spaces
-someBinding' = do
-  x <- getLine
-  y <- getLine
-  putStrLn $ x <> y
-```
-
-#### Case expressions
-
-```haskell
--- Bad - aligning to case pushes expressions way to the left, and aligning
--- arrows is fiddly
-someBinding mx = case mx of
-                   Nothing -> 0
-                   Just x  -> x
-
--- Good - case on its own line, arrows don't need to be lined up
-someBinding' mx =
-  case mx of
-    Nothing -> 0
-    Just x -> x
-
--- If your case-alternatives are more complex, you can put them on their own line:
-someBinding'' mx =
-  case mx of
-    Nothing ->
-      putStrLn "Got nothin'"
-    Just x ->
-      putStrLn $ "Got " <> show x
-```
-
-#### Let expressions
-
-```haskell
--- Bad - aligning multiple let bindings like this is fiddly
-someBinding mx =
-  let ma = fmap (+1) mx
-      mb = fmap (*2) mx
-  in (+) <$> ma <*> mb
-
--- Good - put `let` and `in` on its own line and then we can use normal spacing
-someBinding''' mx =
-  let
-    ma = fmap (+1) mx
-    mb = fmap (*2) mx
-  in
-    (+) <$> ma <*> mb
-
--- Fine to keep on same line when you only have one binding, but use your judgement
-someBinding'' mx =
-  let ma = fmap (+1) mx
-  in maybe 0 (*2) ma
-```
-
-#### Where bindings
-
-Expressions with `where`-bindings should place the body of the expression (if on
-the next line) and the `where`-bindings at the same (2-space) indentation, with
-the `where` keyword de-dented 1 space. Note that this causes an odd, 1-space
-indentation of the `where` keyword.
-
-```haskell
--- Bad - the `where` disappears
-someBinding mx = f <$> mx <*> mx where f x y = x * x + y * y
-
--- Bad - the alignment is fiddly
-someBinding' mx = g $ f <$> mx <*> mx
-  where f x y = x * x + y * y
-        g = maybe 0 (*2)
-
--- OK, but dissallowed in the interest of consistency
-someBinding' mx = g $ f <$> mx <*> mx
-  where
-    f x y = x * x + y * y
-    g = maybe 0 (*2)
-
--- Good
-someBinding mx =
-  f <$> mx <*> mx
- where
-  f x y = x * x + y * y
-
--- Good - use the same indentation for non-multi-line expressions to avoid
--- having to change anything if/when they grow more lines
-someBinding mx = f <$> mx <*> mx
- where
-  f x y = x * x + y * y
-```
-
-#### Lists and Tuples
-
-```haskell
--- Short lists and tuples can be placed on one line
-names = ["Joe", "Bob", "Sam"]
-car = ("Acura", "Integra", 2000)
-
--- Multiline lists and tuples and have commas first
-names' =
-  [ "Joe"
-  , "Bob"
-  , "Same"
-  ]
-
-car' =
-  ( "Acura"
-  , "Integra"
-  , 2000
-  )
-
--- You're more likely to see multiline records than tuples
-teacher =
-  Teacher
-    { firstName = "First"
-    , lastName = "Last"
-    , schoolId = 123
-    , hasPremium = True
-    }
-```
+**Automated**.
 
 ## Imports
+
+**Automated**: formatting of the import statements themselves.
 
 Haskell's modules expose some variety in import style:
 
@@ -472,27 +193,6 @@ import qualified Data.Map as Map
 import qualified Data.Text as Text
 ```
 
-**NOTE**: if explicit imports exceed 80 columns, switch to a (sorted) list:
-
-```haskell
--- Bad
--- Long lines are hard to scan, inserting or removing an item is a noisier diff,
--- and it's difficult to sort a horizontal list
-import System.IO (hPutStrLn, stderr, stdout, withFile, IOMode(..), hGetContents, hFlush, hClose)
-
--- Good
-import System.IO
-  ( IOMode(..)
-  , hClose
-  , hFlush
-  , hGetContents
-  , hPutStrLn
-  , stderr
-  , stdout
-  , withFile
-  )
-```
-
 While we don't prefer writing all modules to assume they'll be qualified, there
 are cases where we implement related modules to share an interface of functions.
 In such cases, we would use un-qualified naming and expect `qualified` imports:
@@ -519,35 +219,21 @@ main = do
 
 ### Importing types and qualifying
 
-It is also common to explicitly import types from a module and also import it
-qualified.
+For modules that exports a type and (clashing) identifiers for operating on that
+type, import the type un-qualified and the rest of the module qualified:
 
-```
+```hs
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Text (Text)
+import qualified Data.Text as T
 ```
 
 ### Abbreviating qualifications
 
-There are a number of common abbreviations that are used in the community to
-qualify imports.
-
-```haskell
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.Encoding as TL
-
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy.Char8 as BSL8
-
-import qualified Data.List.NonEmpty as NE
-
-import qualified Data.Sequence as Seq
-```
+**Automated**.
 
 ### Import groups
 
@@ -555,95 +241,15 @@ Put one blank line between `module`-`where` and the start of your `import`s. Put
 your preferred prelude (when explicit) first, followed by a blank line, then the
 rest of your imports.
 
-The main `import` group should be maintained by our `stylish-haskell`
-configuration.
-
-For vim users,
-
-```vim
-:stylish-haskell %
-
-" or visually select the imports and
-:'<,'>!stylish-haskell
-```
-
-An example of its results at the time of this writing is shown below, but what
-it actually does is less important than the fact that it's automated.
-
-```haskell
--- Bad
--- Improper spacing, improper sorting
-module Foo
-  ( bar
-  , baz
-  ) where
-import qualified Data.Map as Map
-import TextAssets.S3
-import Data.Text (Text)
-import Unit
-import Json
-import Control.Lens
-import qualified Data.Set as Set
-import ClassyPrelude
-import Network.AWS.S3
-import Data.Set (Set)
-import qualified Data.Text as T
-import Network.AWS
-import Data.Map (Map)
-import Data.Conduit
-
--- Good
-module Foo
-  ( bar
-  , baz
-  ) where
-
-import ClassyPrelude
-
-import Control.Lens
-import Data.Conduit
-import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Set (Set)
-import qualified Data.Set as Set
-import Data.Text (Text)
-import qualified Data.Text as T
-import Json (Json)
-import qualified Json as J
-import Network.AWS
-import Network.AWS.S3
-import TextAssets.S3
-import Unit
-```
-
 ## Exports
 
-Use sorted, multi-line exports. There are two exceptions to this rule:
+**Automated**: the formatting of `module (...) where` itself.
 
-1. A single-line export for `Main`, when it only exports `main`:
-
-   ```haskell
-   module Main (main) where
-   ```
-
-1. If the order of exports matters in your desired Haddock output, you may
-   violate sorting to achieve it.
-
-Otherwise:
-
-```haskell
--- Bad
-module Driver (scienceOptions, socialStudiesOptions, mainWith) where
-
--- Good
-module Driver
-  ( mainWith
-  , scienceOptions
-  , socialStudiesOptions
-  ) where
-```
+Sort your exports, unless the order matters in your desired Haddock output.
 
 ## Declaring Extensions
+
+**Automated**: sorting and formatting of extension pragmas.
 
 * All Haskell packages MUST use the following `default-extensions`:
 
@@ -681,19 +287,6 @@ module Driver
   extensions MUST be defined via LANGUAGE pragmas in the modules where they're
   needed.
 
-* Place extensions on their own line, and sort them
-
-  ```haskell
-  -- Bad
-  {-# LANGUAGE OverloadedStrings, RecordWildCards,
-      DataKinds #-}
-
-  -- Good
-  {-# LANGUAGE DataKinds #-}
-  {-# LANGUAGE OverloadedStrings #-}
-  {-# LANGUAGE RecordWildCards #-}
-  ```
-
 * Leave a blank line after the extensions list
 
   ```haskell
@@ -701,8 +294,7 @@ module Driver
 
   module Foo
     ( foo
-    ) where
-
+    )
   ```
 
   ```haskell
@@ -714,8 +306,7 @@ module Driver
   --
   module Foo
     ( foo
-    ) where
-
+    )
   ```
 
 ## Haddocks
@@ -1062,7 +653,8 @@ Bodies are optional but encouraged. When present, the following applies:
     -- * Internal
     -- $internal
     , internalDeleteFoo
-    ) where
+    )
+  where
 
   -- $foo
   -- Operates on Foos


### PR DESCRIPTION
Much of our Guide was specifying things we now leave to tools like
Brittany. This change updates the Guide to not duplicate whatever the
current behavior of our style automation happens to be, and instead
indicates that it being automated is the real guide.