### PR TITLE
Changes to default-extensions guide

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -256,6 +256,7 @@ Sort your exports, unless the order matters in your desired Haddock output.
   ```yaml
   default-extensions:
     - BangPatterns
+    - DataKinds
     - DeriveAnyClass
     - DeriveFoldable
     - DeriveFunctor

--- a/haskell-style.md
+++ b/haskell-style.md
@@ -285,6 +285,14 @@ Sort your exports, unless the order matters in your desired Haddock output.
   extensions MUST be defined via LANGUAGE pragmas in the modules where they're
   needed.
 
+  We allow our `entities` package to diverge from this list, since it is almost
+  entirely persistent Entity definitions. Within this package only, we also have
+  the following enabled by default:
+
+  - `QuasiQuotes`
+  - `TemplateHaskell`
+  - `UndecidableInstances`
+
 - Leave a blank line after the extensions list
 
   ```haskell

--- a/haskell-style.md
+++ b/haskell-style.md
@@ -281,9 +281,6 @@ Sort your exports, unless the order matters in your desired Haddock output.
     - TypeFamilies
   ```
 
-  **NOTE**: `NoImplicitPrelude` may be omitted in packages using the normal,
-  implicit `Prelude` everywhere.
-
   This defines a consistent, and minimally-extended Haskell environment. Other
   extensions MUST be defined via LANGUAGE pragmas in the modules where they're
   needed.


### PR DESCRIPTION
There are three commits:

- 5fb9380 Document entities extensions caveat

- c853459 Remove caveat about NoImplicitPrelude

  We actually don't make use of this caveat. We just import Prelude explicitly,
  and it seems fine so far.

- 56a4fa1 Add DataKinds to default-extensions

  This commit has our Guide match reality, as this was already enabled in all
  packages anyway.

  DataKinds is relatively innocuous and, while we consider it an _Isolate_
  generally so as not to build things on it, we do _use_ quite a few thing that
  require it be enabled. For example:

  - Anything using a type-level symbol (Tagged, Closed, Envelope etc)
  - Any Graphula tests with type signatures (i.e. GraphulaContext m '[])

  Therefore, it makes sense in default-extensions.

I discussed this in Slack ahead of time, and don't expect much objection to
these, so I decided to just group them into one PR. If anyone wants to discuss
any one in isolation, just say so and I can slice it off separately.