### PR TITLE
Add prefer patch over put

### DIFF
--- a/haskell-api.md
+++ b/haskell-api.md
@@ -97,7 +97,7 @@ possible. Issues include:
 - The necessity of sending monolithic resources to a `PUT` when most uses are
   changing specific details.
 - The ability to misinterpret an `undefined` as a `null` and have untintended
-  consequences when evolving a handler. This is exasterbated by the default
+  consequences when evolving a handler. This is exacerbated by the default
   parsing behavior of `Maybe a` in `aeson`.
 - The complexities that arise from extra validation or lack of validation
   especially when differing rules around mutability and roles arise.

--- a/haskell-api.md
+++ b/haskell-api.md
@@ -87,6 +87,24 @@ This is because:
   - `students: [{id:, firstName:, lastName:}]`
   - `school: {id:, name:}`
 
+## HTTP Methods
+
+### Prefer `PATCH` over `PUT`
+
+`PUT` routes contain semantics that easily lead to bugs. We prefer `PATCH` when
+possible. Issues include:
+
+* The necessity of sending monolithic resources to a `PUT` when most uses are
+  changing specific details.
+* The ability to misinterpret an `undefined` as a `null` and have untintended
+  consequences when evolving a handler. This is exasterbated by the default
+  parsing behavior of `Maybe a` in `aeson`.
+* The complexities that arise from extra validation or lack of validation
+  especially when differing rules around mutability and roles arise.
+
+If you are creating a new `PUT` consider if it could be expressed in a more
+granular `PATCH` semantic.
+
 ## Status Codes
 
 - 201 for creation

--- a/haskell-api.md
+++ b/haskell-api.md
@@ -94,12 +94,12 @@ This is because:
 `PUT` routes contain semantics that easily lead to bugs. We prefer `PATCH` when
 possible. Issues include:
 
-* The necessity of sending monolithic resources to a `PUT` when most uses are
+- The necessity of sending monolithic resources to a `PUT` when most uses are
   changing specific details.
-* The ability to misinterpret an `undefined` as a `null` and have untintended
+- The ability to misinterpret an `undefined` as a `null` and have untintended
   consequences when evolving a handler. This is exasterbated by the default
   parsing behavior of `Maybe a` in `aeson`.
-* The complexities that arise from extra validation or lack of validation
+- The complexities that arise from extra validation or lack of validation
   especially when differing rules around mutability and roles arise.
 
 If you are creating a new `PUT` consider if it could be expressed in a more


### PR DESCRIPTION
A recent post-mortem lead to the consensus that `PATCH` methods are
superior to `PUT`. The `PUT` method exposes many gotchas and risks in
the development process. This adds a guide to encode our beliefs.

- Post Mortem: https://renaissancelearning.atlassian.net/wiki/spaces/EN/pages/1629487213/2021-03-12+CRM+ID+Deletion+Post+Mortem
- Code Climate Error: https://github.com/freckle/megarepo/pull/15959
- Asana debt task: https://app.asana.com/0/399653121150251/1200094903267017/f