### PR TITLE
Add `PATCH` semantics

### DIFF
--- a/haskell-api.md
+++ b/haskell-api.md
@@ -126,8 +126,9 @@ Modifications to an existing resource should be made via a `PATCH` request.
 A well-formed `PATCH` endpoint
 
 - Must update an entity's `updatedAt` field, if present.
-- Should return the modified resource. The resource should be re-fetched for
-  ease of testing and to ensure the update was correctly persisted.
+- Should return the modified resource. The resource should be re-fetched from
+  the database for ease of testing and to ensure the update was correctly
+  persisted.
 - Must accept `null` to unset nullable fields, disallowing it for
   non-nullables.
 - Must 404 if a resource with the route's identifier(s) does not exist.

--- a/haskell-api.md
+++ b/haskell-api.md
@@ -182,7 +182,7 @@ For example, assuming `GET /3/teachers/7654` yields
   "phoneNumber": null
 }
 
-// Do nothing, no-op update
+// Do nothing, still updates `updatedAt`
 {
 }
 ```

--- a/haskell-api.md
+++ b/haskell-api.md
@@ -126,9 +126,8 @@ Modifications to an existing resource should be made via a `PATCH` request.
 A well-formed `PATCH` endpoint
 
 - Must update an entity's `updatedAt` field, if present.
-- Must return an empty response or the modified resource. If the latter, the
-  the resource should be re-fetched for ease of testing and to ensure
-  the update was correctly persisted.
+- Should return the modified resource. The resource should be re-fetched for
+  ease of testing and to ensure the update was correctly persisted.
 - Must accept `null` to unset nullable fields, disallowing it for
   non-nullables.
 - Must 404 if a resource with the route's identifier(s) does not exist.

--- a/haskell-api.md
+++ b/haskell-api.md
@@ -124,36 +124,39 @@ Modifications to an existing resource should be made via a `PATCH` request.
 ### Specific guidelines
 
 A well-formed `PATCH` endpoint
- - Should update an entity's `updatedAt` field, if present.
- - Should return an empty response or the modified resource. Ideally, if the
-   latter, the resource should be re-fetched for ease of testing and to ensure
-   the update was correctly persisted.
- - Should accept `null` to unset nullable fields, disallowing it for
-   non-nullables.
- - Should 404 if a resource with the route's identifier(s) does not exist.
- - Should not allow for update-scoping information within the `PATCH` object. If
-   scoping information is absolutely necessary, it should be include in query
-   params.
- - Should not create resources (that's the role of `POST`).
- - Should allow for fields to be optional, even allowing for entirely empty
-   `PATCH` objects.
- - Should not allow for unsupported keys.
+
+- Should update an entity's `updatedAt` field, if present.
+- Should return an empty response or the modified resource. Ideally, if the
+  latter, the resource should be re-fetched for ease of testing and to ensure
+  the update was correctly persisted.
+- Should accept `null` to unset nullable fields, disallowing it for
+  non-nullables.
+- Should 404 if a resource with the route's identifier(s) does not exist.
+- Should not allow for update-scoping information within the `PATCH` object. If
+  scoping information is absolutely necessary, it should be include in query
+  params.
+- Should not create resources (that's the role of `POST`).
+- Should allow for fields to be optional, even allowing for entirely empty
+  `PATCH` objects.
+- Should not allow for unsupported keys.
 
 #### Structural similarities to `GET`
 
 As a rule-of-thumb for a given resource, `PATCH` requests share a similar shape
 to `GET` requests in that
- - they should have the same route (e.g. `/3/teachers/7654` would `GET` or
-   `PATCH` the teacher with id `7654`),
- - `PATCH` objects should resemble the fields yielded by the corresponding `GET`,
-   albeit `PATCH` fields are (1) optional, (2) may allow additional fields or (3)
-   disallow the modification of certain fields (e.g. `id`, `createdAt`), and
- - if a `PATCH` response is non-empty, it should be the same payload that would
-   be returned by a call to the corresponding `GET`.
+
+- they should have the same route (e.g. `/3/teachers/7654` would `GET` or
+  `PATCH` the teacher with id `7654`),
+- `PATCH` objects should resemble the fields yielded by the corresponding `GET`,
+  albeit `PATCH` fields are (1) optional, (2) may allow additional fields or (3)
+  disallow the modification of certain fields (e.g. `id`, `createdAt`), and
+- if a `PATCH` response is non-empty, it should be the same payload that would
+  be returned by a call to the corresponding `GET`.
 
 #### Example
-   
+
 For example, assuming `GET /3/teachers/7654` yields
+
 ```json
 {
   "id": 7654,
@@ -166,12 +169,13 @@ For example, assuming `GET /3/teachers/7654` yields
   "country": "USA",
   "gradesTaught": ["K"],
   "createdAt": "2021-11-10T15:29:16.239Z",
-  "updatedAt": "2021-11-10T15:29:16.239Z",
+  "updatedAt": "2021-11-10T15:29:16.239Z"
 }
 ```
 
 `PATCH /3/teachers/7654` could accept the following update payloads
-``` javascript
+
+```javascript
 // Change the teacher's name
 {
   "givenName": "Arnold",
@@ -189,7 +193,8 @@ For example, assuming `GET /3/teachers/7654` yields
 ```
 
 However, `PATCH /3/teachers/7654` would fail given the following payloads
-``` javascript
+
+```javascript
 // BAD REQUEST, trying to unset a required field
 {
   "email": null

--- a/haskell-api.md
+++ b/haskell-api.md
@@ -182,8 +182,13 @@ For example, assuming `GET /3/teachers/7654` yields
   "phoneNumber": null
 }
 
-// Do nothing, still updates `updatedAt`
+// Updates `updatedAt`
 {
+}
+
+// Updates `updatedAt` (immutable fields and unsupported fields are ignored)
+{
+  "createdAt": "2019-11-10T15:29:16.239Z"
 }
 ```
 
@@ -193,11 +198,6 @@ However, `PATCH /3/teachers/7654` would fail given the following payloads
 // BAD REQUEST, trying to unset a required field
 {
   "email": null
-}
-
-// BAD REQUEST, trying to set a field that cannot be modified
-{
-  "createdAt": "2019-11-10T15:29:16.239Z"
 }
 
 // BAD REQUEST, validation found `ZZ` is not within `USA`

--- a/haskell-api.md
+++ b/haskell-api.md
@@ -138,7 +138,6 @@ A well-formed `PATCH` endpoint
 - Should not create resources (that's the role of `POST`).
 - Should allow for fields to be optional, even allowing for entirely empty
   `PATCH` objects.
-- Should not allow for unsupported keys.
 
 #### Structural similarities to `GET`
 
@@ -203,11 +202,6 @@ However, `PATCH /3/teachers/7654` would fail given the following payloads
 // BAD REQUEST, trying to set a field that cannot be modified
 {
   "createdAt": "2019-11-10T15:29:16.239Z"
-}
-
-// BAD REQUEST, trying to set an unsupported field
-{
-  "unsupportedField": "hi"
 }
 
 // BAD REQUEST, validation found `ZZ` is not within `USA`

--- a/haskell-api.md
+++ b/haskell-api.md
@@ -125,16 +125,16 @@ Modifications to an existing resource should be made via a `PATCH` request.
 
 A well-formed `PATCH` endpoint
 
-- Should update an entity's `updatedAt` field, if present.
-- Should return an empty response or the modified resource. Ideally, if the
-  latter, the resource should be re-fetched for ease of testing and to ensure
+- Must update an entity's `updatedAt` field, if present.
+- Must return an empty response or the modified resource. If the latter, the
+  the resource should be re-fetched for ease of testing and to ensure
   the update was correctly persisted.
-- Should accept `null` to unset nullable fields, disallowing it for
+- Must accept `null` to unset nullable fields, disallowing it for
   non-nullables.
-- Should 404 if a resource with the route's identifier(s) does not exist.
-- Should not create resources (that's the role of `POST`).
-- Should allow for fields to be optional, even allowing for entirely empty
-  `PATCH` objects.
+- Must 404 if a resource with the route's identifier(s) does not exist.
+- Must not create resources (that's the role of `POST`).
+- Must allow for fields to be optional, even allowing for entirely empty `PATCH`
+  objects.
 
 #### Structural similarities to `GET`
 

--- a/haskell-api.md
+++ b/haskell-api.md
@@ -132,9 +132,6 @@ A well-formed `PATCH` endpoint
 - Should accept `null` to unset nullable fields, disallowing it for
   non-nullables.
 - Should 404 if a resource with the route's identifier(s) does not exist.
-- Should not allow for update-scoping information within the `PATCH` object. If
-  scoping information is absolutely necessary, it should be include in query
-  params.
 - Should not create resources (that's the role of `POST`).
 - Should allow for fields to be optional, even allowing for entirely empty
   `PATCH` objects.


### PR DESCRIPTION
Having recently converted our remaining `PUT` routes to `PATCH` I thought it would be nice to unify and formalize some of the differing practices in the API.

I believe that some of these formalizations could benefit our backend testing and frontend implementations.

If `PATCH` returns the same value as `GET`, and is the same route, then frontend
 - wouldn't need to re-fetch updated entities (not sure if we do this often, I've seen it a good deal in past lives)
 - could reuse types and code used by the original `GET`
 - would (theoretically) need to manage less state since it could just trust what `PATCH` yields rather than having it's own duplicate state store to maintain
 
These formalizations are nice for the backend because
 - we should be able to generate tests from a description of the fields a `PATCH` expects and expected outcomes thereabouts
 - allowing for empty `PATCH` objects and re-fetching would allow us to implement `GET /some/route/123` as `PATCH {} /some/route/123`, or, conversely, we could implement the re-fetching using the `GET` (though that's not really a benefit).
 
Note that  our current `PATCH` endpoints do not conform to these guidelines, in many cases. If this guideline is accepted I will file debt for the places that don't conform for the backend guild to prioritize.