### PR TITLE
Add `QuasiQuotes` to default extension list

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -274,6 +274,7 @@ Sort your exports, unless the order matters in your desired Haddock output.
     - NoImplicitPrelude
     - NoMonomorphismRestriction
     - OverloadedStrings
+    - QuasiQuotes
     - RankNTypes
     - RecordWildCards
     - ScopedTypeVariables
@@ -290,7 +291,6 @@ Sort your exports, unless the order matters in your desired Haddock output.
   entirely persistent Entity definitions. Within this package only, we also have
   the following enabled by default:
 
-  - `QuasiQuotes`
   - `TemplateHaskell`
   - `UndecidableInstances`
 

--- a/haskell-style.md
+++ b/haskell-style.md
@@ -692,6 +692,5 @@ Bodies are optional but encouraged. When present, the following applies:
 
 [markup]: https://www.haskell.org/haddock/doc/html/ch03s08.html
 [chunks]: https://www.haskell.org/haddock/doc/html/ch03s05.html
-[tbaggery]:
-  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[tbaggery]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [progressive_disclosure]: https://en.wikipedia.org/wiki/Progressive_disclosure


### PR DESCRIPTION
**Why?**

Since we use this extension throughout our tests (e.g. `aesonQQ`) and our entity
definitions (e.g. `persistLowerCase`) it seems appropriate to enable it across
our projects by default.