### PR TITLE
Note `haskell-library-template` in OSS instructions

### DIFF
--- a/haskell-open-source.md
+++ b/haskell-open-source.md
@@ -2,8 +2,8 @@
 
 1. If authoring a distinct package of reasonable size and generic utility,
    prefer starting a separate, public repository utilized as a Git dependency.
-   A Haskell library template includes common setup for tooling and actions:
-   `gh repo create --template freckle/haskell-library-template`
+
+Templates may exist for common cases, such as a [Haskell library][gh-hlt].
 
 When working in a public repository:
 
@@ -66,3 +66,5 @@ To determine what changes are "breaking", use the following:
 ![](./pvp-chart.png)
 
 With `A=EPOCH`, `B=MAJOR`, and `C=MINOR`.
+
+[gh-hlt]: https://github.com/freckle/haskell-library-template

--- a/haskell-open-source.md
+++ b/haskell-open-source.md
@@ -1,7 +1,9 @@
 # Best Practices
 
 1. If authoring a distinct package of reasonable size and generic utility,
-   prefer starting a separate, public repository utilized as a Git dependency
+   prefer starting a separate, public repository utilized as a Git dependency.
+   A Haskell library template includes common setup for tooling and actions:
+   `gh repo create --template freckle/haskell-library-template`
 
 When working in a public repository:
 


### PR DESCRIPTION
This was added recently and provides a good starting point for Haskell libraries.