### PR TITLE
Remove Haskell testing doc

### DIFF
--- a/haskell-testing.md
+++ b/haskell-testing.md
@@ -1,7 +1,0 @@
-# Testing Haskell at Front Row
-
-## Best practices for raw hspec
-
-## Caching data for quicker test runs
-
-## Introduction to poly-graph


### PR DESCRIPTION
**Why?**

It's empty, out of date, and covered in guides/haskell-best-practices.md.