### PR TITLE
Align incidental parts of examples with style

### DIFF
--- a/haskell-api.md
+++ b/haskell-api.md
@@ -338,3 +338,8 @@ body
 body <- getJsonBody
 body `shouldMatchList` [TeacherGet teacherId]
 ```
+
+For asserting against JSON bodies while ignoring extra fields or ordering, use
+[hspec-expectations-json][].
+
+[hspec-expectations-json]: https://hackage.haskell.org/package/hspec-expectations-json

--- a/haskell-best-practices.md
+++ b/haskell-best-practices.md
@@ -179,33 +179,30 @@ Sometimes you have two types which are very similar, both in their
 representations and in how they're used. For example,
 
 ```haskell
-data Foo
-  = Foo
+data Foo = Foo
   { a :: Int
   , b :: Int
   , c :: Int
   }
 
- data Bar
-   = Bar
-   { a :: Int
-   , b :: Int
-   , c :: Int
-   , d :: Int
-   }
+data Bar = Bar
+  { a :: Int
+  , b :: Int
+  , c :: Int
+  , d :: Int
+  }
 ```
 
 It would be a pain to duplicate functions which operate on these types. A first
 attempt to avoid that might be:
 
 ```haskell
-data FooBar
-  = FooBar
-   { a :: Int
-   , b :: Int
-   , c :: Int
-   , d :: Maybe Int
-   }
+data FooBar = FooBar
+  { a :: Int
+  , b :: Int
+  , c :: Int
+  , d :: Maybe Int
+  }
 ```
 
 but we lose value type safety/documentation here.
@@ -216,16 +213,15 @@ A better approach is to parameterize the field which varies:
 type Never = Proxy
 type Always = Identity
 
-data FooBar f
-  = FooBar
-   { a :: Int
-   , b :: Int
-   , c :: Int
-   , d :: f Int
-   }
+data FooBar f = FooBar
+  { a :: Int
+  , b :: Int
+  , c :: Int
+  , d :: f Int
+  }
 
- type Foo = FooBar Never
- type Bar = FooBar Always
+type Foo = FooBar Never
+type Bar = FooBar Always
 ```
 
 This lets us share the commonalities and still differentiate in a safe way. But
@@ -239,13 +235,12 @@ type family OnlyIfBar (x :: FooBarType) (a :: *) :: * where
   OnlyIfBar Foo a = ()
   OnlyIfBar Bar a = a
 
-data FooBar (x :: FooBarType)
-  = FooBar
-   { a :: Int
-   , b :: Int
-   , c :: Int
-   , d :: OnlyIfBar x Int
-   }
+data FooBar (x :: FooBarType) = FooBar
+  { a :: Int
+  , b :: Int
+  , c :: Int
+  , d :: OnlyIfBar x Int
+  }
 ```
 
 With this approach `d :: FooBar Foo -> ()` (total absence of `d` would be the
@@ -263,7 +258,9 @@ Newtypes in Haskell are used for 3 primary purposes:
 1 allows us to communicate clearly and increase type safety:
 
 ```haskell
-newtype City = City { unCity :: String }
+newtype City = City
+  { unCity :: String
+  }
 
 sf :: City
 sf = City "San Francisco"
@@ -284,7 +281,10 @@ sf = "San Francisco"
 ```haskell
 module Natural (Natural(), mkNatural) where
 
-newtype Natural = Natural { unNatural :: Int }
+newtype Natural = Natural
+  { unNatural :: Int
+  }
+
 mkNatural :: Int -> Maybe Natural
 mkNatural n = if n >= 0 then Just (Natural n) else Nothing
 ```
@@ -292,13 +292,17 @@ mkNatural n = if n >= 0 then Just (Natural n) else Nothing
 3 looks like:
 
 ```haskell
-newtype Add = Add { unAdd :: Int }
+newtype Add = Add
+  { unAdd :: Int
+  }
 
 instance Monoid Add where
   mempty = 0
   mappend = (+)
 
-newtype Mult = Mult { unMult :: Int }
+newtype Mult = Mult
+  { unMult :: Int
+  }
 
 instance Monoid Mult where
   mempty = 1
@@ -311,7 +315,9 @@ The `Tagged` example above makes use of a phantom type variable. The definition
 of `Tagged` is:
 
 ```haskell
-newtype Tagged t a = Tagged { untag :: a }
+newtype Tagged t a = Tagged
+  { untag :: a
+  }
 ```
 
 Note how the type variable `t` does not appear on the right-hand-side of the
@@ -366,12 +372,12 @@ integers, bools, addition, and conditions:
 
 ```haskell
 data Expr
-  | I Int
+  = I Int
   | B Bool
   | Add Expr Expr
   | LessThan Expr Expr
   | Cond Expr Expr Expr
-    deriving (Eq, Show)
+  deriving stock (Eq, Show)
 ```
 
 We can construct values like `Add (I 1) (I 3)` to represent `1 + 3`, but there's
@@ -385,16 +391,16 @@ data Value
   | VB Bool
 
 eval :: Expr -> Maybe Value
-eval (I i) = return $ VI i
-eval (B b) = return $ VB b
+eval (I i) = pure $ VI i
+eval (B b) = pure $ VB b
 eval (Add x y) = do
   VI x' <- eval x
   VI y' <- eval y
-  return $ VI $ x' + y'
+  pure $ VI $ x' + y'
 eval (LessThan x y) = do
   VI x' <- eval x
   VI y' <- eval y
-  return $ VB $ x' < y'
+  pure $ VB $ x' < y'
 eval (Cond c t f) = do
   VB c' <- eval c
   if c'

--- a/haskell-style.md
+++ b/haskell-style.md
@@ -68,17 +68,17 @@ That isn't to say we prefer `=<<` over `>>=`
 ```haskell
 -- Good
 result <-
-      action4
-  =<< action3
-  =<< action2
-  =<< action1
+  action4
+    =<< action3
+    =<< action2
+    =<< action1
 
 -- Better
 result <-
-      action1
-  >>= action2
-  >>= action3
-  >>= action4
+  action1
+    >>= action2
+    >>= action3
+    >>= action4
 
 -- Good: this is easy to read left-to-right and scales as the lambda grows
 
@@ -205,7 +205,7 @@ import FrontRow.Jobs.DeleteTeacher (enqueueDeleteTeacher)
 main = do
   if shouldDeleteTeacher teacher
     then enqueueDeleteTeacher teacher
-    then enqueueSyncTeacher teacher
+    else enqueueSyncTeacher teacher
 
 -- Good
 import qualified FrontRow.Jobs.SyncTeacher as SyncTeacher
@@ -214,7 +214,7 @@ import qualified FrontRow.Jobs.DeleteTeacher as DeleteTeacher
 main = do
   if shouldDeleteTeacher teacher
     then DeleteTeacher.enqueue teacher
-    then SyncTeacher.enqueue teacher
+    else SyncTeacher.enqueue teacher
 ```
 
 ### Importing types and qualifying
@@ -355,8 +355,7 @@ yet requiring a certain level of coverage, but it is strongly encouraged.
   Bad
 
   ```hs
-  data Foo
-    = Foo
+  data Foo = Foo
     {
     -- | Foo's foo
       fooFoo :: Foo
@@ -370,8 +369,7 @@ yet requiring a certain level of coverage, but it is strongly encouraged.
 
   ```hs
   -- | A mispelling of fu to avoid detection when coupled with Bar
-  data Foo
-    = Foo
+  data Foo = Foo
     { fooFoo :: Foo
     -- ^ Foo's foo
     , fooBar :: Bar
@@ -383,8 +381,7 @@ yet requiring a certain level of coverage, but it is strongly encouraged.
 
   ```hs
   -- | A mispelling of fu to avoid detection when coupled with Bar
-  data Foo
-    = Foo
+  data Foo = Foo
     { fooFoo :: Foo -- ^ Foo's foo
     , fooBar :: Bar -- ^ Foo's bar
     }
@@ -395,8 +392,7 @@ yet requiring a certain level of coverage, but it is strongly encouraged.
   Bad
 
   ```hs
-  data Foo
-    = Foo
+  data Foo = Foo
     { fooFoos :: [Foo] -- ^ Foo's foos
     , fooBar :: Bar    -- ^ Foo's bar
     }
@@ -405,8 +401,7 @@ yet requiring a certain level of coverage, but it is strongly encouraged.
   Good
 
   ```hs
-  data Foo
-    = Foo
+  data Foo = Foo
     { fooFoos :: [Foo] -- ^ Foo's foos
     , fooBar :: Bar -- ^ Foo's bar
     }
@@ -417,8 +412,7 @@ yet requiring a certain level of coverage, but it is strongly encouraged.
   Bad
 
   ```hs
-  data Foo
-    = Foo
+  data Foo = Foo
     { fooFoos :: [Foo] -- ^ Foo's foos is getting really long and might be
                        -- multiple sentences. You might want to go
                        -- context-sensitive too!
@@ -429,8 +423,7 @@ yet requiring a certain level of coverage, but it is strongly encouraged.
   Good
 
   ```hs
-  data Foo
-    = Foo
+  data Foo = Foo
     { fooFoos :: [Foo]
     -- ^ Foo's foos
     --


### PR DESCRIPTION
Some of our code examples were written not following our style in ways
that weren't the actual point of whatever rule they're appearing in.
This commit goes through and addresses those -- mostly record
formatting.
