### PR TITLE
recommend GHC2021

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -234,7 +234,7 @@ Sort your exports, unless the order matters in your desired Haddock output.
 
 **Automated**: sorting and formatting of extension pragmas.
 
-- All Haskell packages MUST use the following language version and `default-extensions`:
+- All Haskell packages MUST use the following `language` and `default-extensions`:
 
   ```yaml
   language: GHC2021

--- a/haskell-style.md
+++ b/haskell-style.md
@@ -234,35 +234,23 @@ Sort your exports, unless the order matters in your desired Haddock output.
 
 **Automated**: sorting and formatting of extension pragmas.
 
-- All Haskell packages MUST use the following `default-extensions`:
+- All Haskell packages MUST use the following language version and `default-extensions`:
 
   ```yaml
+  language: GHC2021
+
   default-extensions:
-    - BangPatterns
     - DataKinds
     - DeriveAnyClass
-    - DeriveFoldable
-    - DeriveFunctor
-    - DeriveGeneric
-    - DeriveLift
-    - DeriveTraversable
     - DerivingStrategies
     - DerivingVia
-    - FlexibleContexts
-    - FlexibleInstances
     - GADTs
-    - GeneralizedNewtypeDeriving
     - LambdaCase
-    - MultiParamTypeClasses
     - NoImplicitPrelude
     - NoMonomorphismRestriction
     - OverloadedStrings
     - QuasiQuotes
-    - RankNTypes
     - RecordWildCards
-    - ScopedTypeVariables
-    - StandaloneDeriving
-    - TypeApplications
     - TypeFamilies
   ```
 


### PR DESCRIPTION
Recommends using [GHC2021](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/control.html#extension-GHC2021) as the language version, and removes from our list extensions that are redundant to GHC2021.

Will wait a while on this to leave room for any discussion.

This description of the change is primarily based on the GHC 9.2 docs.

This implies the enabling of all the following extensions that the guide did not suggest previously:

- [`NamedFieldPuns`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/record_puns.html?highlight=namedfieldpuns) - Allows contracting `A{x=x}` to `A{x}` in expressions and patterns
- [`NamedWildCards`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/partial_type_signatures.html#extension-NamedWildCards) - Allow naming of wildcards (e.g. `_x`) in type signatures
- New numeric literal forms: `BinaryLiterals`, `HexFloatLiterals`, `NumericUnderscores`
- Allowing more explicit signatures: `InstanceSigs`, `KindSignatures`, `StandaloneKindSignatures`
- [`DeriveDataTypeable`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/deriving_extra.html#extension-DeriveDataTypeable) - Allows stock deriving of the `Data` class
- [`EmptyDataDeriving`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/empty_data_deriving.html#extension-EmptyDataDeriving) - Permits stock deriving for datatypes with no constructors
- Related to infix operators: [`PostfixOperators`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/rebindable_syntax.html#extension-PostfixOperators), [`TupleSections`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/tuple_sections.html#extension-TupleSections). [`TypeOperators`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/type_operators.html#extension-TypeOperators)
- [`ImportQualifiedPost`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/import_qualified_post.html#extension-ImportQualifiedPost) lets you write `import A qualified as B` instead of `import qualified A as B`
- Changes to type system: [`ConstraintKinds`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/constraint_kind.html#extension-ConstraintKinds), [`ExistentialQuantification`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/existential_quantification.html#extension-ExistentialQuantification), [`PolyKinds`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/poly_kinds.html#extension-PolyKinds)
- [`GADTSyntax`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/gadt_syntax.html#extension-GADTSyntax) - Adds an alternative syntax for defining datatypes
- [`EmptyCase`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/empty_case.html#extension-EmptyCase) - Allows writing a `case` expression that doesn't have any cases (useful in weird circumstances to pattern match over something that's impossible e.g. `Void`)
- [`TypeSynonymInstances`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/instances.html#extension-TypeSynonymInstances) - Allows types defined as `type` aliases to be referenced in the head of typeclass instance definitions
- `DoAndIfThenElse` - Actually I have no idea what this is, it's not documented in the manual.

GHC2021 also disables a few extensions that were previously enabled by Haskell2010:

- [`CUSKs`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/poly_kinds.html#extension-CUSKs)
- [`DatatypeContexts`](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/datatype_contexts.html#extension-DatatypeContexts)

In the [latest](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html#extension-GHC2021) GHC, there is an additional subtlety between Haskell2010 and GHC2021:

- GHC2021 does not enable [`DeepSubsumption`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/rank_polymorphism.html#extension-DeepSubsumption).