### PR TITLE
NoPostfixOperators

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -248,6 +248,7 @@ Sort your exports, unless the order matters in your desired Haddock output.
     - LambdaCase
     - NoImplicitPrelude
     - NoMonomorphismRestriction
+    - NoPostfixOperators
     - OverloadedStrings
     - QuasiQuotes
     - RecordWildCards


### PR DESCRIPTION
`megarepo/backend` is now almost entirely on GHC2021. Of all the new extensions enabled by [adopting GHC2021](#87), one I think we should backtrack on is [PostfixOperators](https://downloads.haskell.org/ghc/9.2-latest/docs/html/users_guide/exts/rebindable_syntax.html#extension-PostfixOperators).

- We have no code at all that relies on this extension
- [It introduces a minor regression](https://discourse.haskell.org/t/anybody-using-ghc2021/7095/16) which, in one place in megarepo, causes weeder to give a false positive.