### PR TITLE
Do not prefix record field names

### DIFF
--- a/haskell-best-practices.md
+++ b/haskell-best-practices.md
@@ -109,6 +109,33 @@ been maintained for that as things have evolved.
 - [What I Wish I Knew When Learning Haskell](http://dev.stephendiehl.com/hask/)
 - [Haskell For Web Developers](http://www.stephendiehl.com/posts/haskell_web.html)
 
+## Do not prefix record fields
+
+There was once a time when record field names needed to be unique, and so it was
+conventional to prefix them with a constructor name:
+
+```haskell
+data StudentAssignmentReport =
+  StudentAssignmentReport
+    { studentAssignmentReportId :: UUID
+    , studentAssignmentReportGrade :: Percentage
+    , studentAssignmentReportTitle :: Text
+    }
+```
+
+Thanks to `NoFieldSelectors`, `DuplicateRecordFields`, and `OverloadedRecordDot`,
+it does not matter whether a record field has the same name as anything else, and
+so the prefixed field style is no longer useful. Such names should be shortened:
+
+```haskell
+data StudentAssignmentReport =
+  StudentAssignmentReport
+    { id :: UUID
+    , grade :: Percentage
+    , title :: Text
+    }
+```
+
 ## Existentials
 
 Why / when you want to use them:

--- a/haskell-style.md
+++ b/haskell-style.md
@@ -248,6 +248,7 @@ Sort your exports, unless the order matters in your desired Haddock output.
     - LambdaCase
     - NoImplicitPrelude
     - NoMonomorphismRestriction
+    - OverloadedRecordDot
     - OverloadedStrings
     - QuasiQuotes
     - RecordWildCards

--- a/haskell-style.md
+++ b/haskell-style.md
@@ -244,8 +244,10 @@ Sort your exports, unless the order matters in your desired Haddock output.
     - DeriveAnyClass
     - DerivingStrategies
     - DerivingVia
+    - DuplicateRecordFields
     - GADTs
     - LambdaCase
+    - NoFieldSelectors
     - NoImplicitPrelude
     - NoMonomorphismRestriction
     - OverloadedRecordDot


### PR DESCRIPTION
~I'd like to propose we enable [`OverloadedRecordDot`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/overloaded_record_dot.html) by default everywhere.~

I'm proposing the following changes to the style guide:
- Enable [`OverloadedRecordDot`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/overloaded_record_dot.html), [`DuplicateRecordFields`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/duplicate_record_fields.html#extension-DuplicateRecordFields), and [`NoFieldSelectors`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/field_selectors.html).
- Do not use prefixed record field names.

I've been using this extension set in various isolated places. I wouldn't say for sure there is consensus on this, but it *seems like* we're headed that way...

If you need to see what this looks like in action, browse the [content-client](https://github.com/freckle/content-client) repo, which uses this approach extensively.

### Advantages

The main advantage is decluttering code that can get very noisy when names are too long. Personally I find the long names a real impediment to understanding, especially when both the prefix and the name are multi-word phrases.

Not using prefixes often makes it easier to map Haskell types to JSON schemas. When defining an API type, often the record field names can exactly match the JSON field names.

### Drawbacks

If you destructure a record with NamedFieldPuns or RecordWildCards, it still does bring the name into scope where it can conflict with other identifiers. This comes to light most readily with fields named `id`, since many of the records we deal with have an ID field, and `id` is a function defined in every prelude. Usually this means that I _do not_ want to bring fields into scope in this way, and instead rely quite heavily on `OverloadedRecordDot`. You can also get around the issue by binding an unambiguous local name using ordinary record syntax (`let Student{ id } = student` vs `let Student{ id = studentId } = student`).

`OverloadedRecordDot` does not work with fields that have higher-rank types. This means that if you have a type like `newtype Storage = Storage{ run :: forall a. Operation a -> IO a }`, you cannot access that field by writing `storage.run`. This is not a huge deal for us since we do not often have records like this.