### PR TITLE
Add 'TypeOperators' to default-extensions.

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -255,6 +255,7 @@ Sort your exports, unless the order matters in your desired Haddock output.
     - OverloadedStrings
     - QuasiQuotes
     - TypeFamilies
+    - TypeOperators
   ```
 
   This defines a consistent, and minimally-extended Haskell environment. Other


### PR DESCRIPTION
The 'TypeOperators' extension is documented here:

- https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/type_operators.html#extension-TypeOperators

It is included in 'GHC2021', and thus enabling this extension is consistent with this guide's current recommendation to use 'GHC2021'.

Furthermore, the use of the type equality type operator - '~' - **without** the use of the 'TypeOperators' extension will become an error in future GHC releases.


**If** this guide suggestion is approved, there is a PR to adhere to the recommendation in megarepo:

https://github.com/freckle/megarepo/pull/34415