### PR TITLE
Start haskell persistent guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,13 @@ Conventions for naming database entities, JSON serializations, etc.
 
 ## Haskell
 
-### [Best Practices](./haskell-best-practices.md)
-
-Best practices in a Haskell code base.
-
-### [API](./haskell-api.md)
-
-Best practices in our Haskell API specifically.
-
-### [Style](./haskell-style.md)
-
-Haskell style. **TL;DR**: use Fourmolu.
-
-### [Testing](./haskell-testing.md)
-
-Haskell testing practices, _work in progress_.
+- **[Best Practices](./haskell-best-practices.md)** - Best practices in a Haskell code base.
+- **[API](./haskell-api.md)** - Best practices in our Haskell API specifically.
+- **[Persistent](./haskell-persistent.md)** - Best practices for [persistent](https://hackage.haskell.org/package/persistent)-based database interaction.
+- **[Style](./haskell-style.md)** - Haskell style. TL;DR: use Fourmolu.
+- **[Testing](./haskell-testing.md)** - Haskell testing practices, _work in progress_.
 
 ## Shell
 
-### [Style](./shell-style.md)
-
-Shell style. **TL;DR**: use ShellCheck and shfmt.
-
-## [Open Source](./open-source.md)
-
-Processes and practices for our open source libraries.
+- [Style](./shell-style.md) - Shell style. TL;DR: use ShellCheck and shfmt.
+- [Open Source](./open-source.md) - Processes and practices for our open source libraries.

--- a/haskell-persistent.md
+++ b/haskell-persistent.md
@@ -1,0 +1,67 @@
+# Haskell Persistent Conventions
+
+## Use explicit type application to specify tables
+
+It is nearly always a good idea for a database operation to include somewhere
+a type application for each table involved in the query. Selects usually should
+have a type application on [`table`][table].
+
+Missing a type application:
+
+```hs
+select $ do
+  people <- from $ table
+  where_ $ people ^. #name ==. val "Robin"
+  pure people
+```
+
+Better:
+
+```hs
+select $ do
+  people <- from $ table @Person
+  where_ $ people ^. #name ==. val "Robin"
+  pure people
+```
+
+## Refer to entity fields by symbol
+
+Enable the [`OverloadedLabels`][overloaded-labels] Haskell extension.
+
+Do not:
+
+```hs
+select $ do
+  people <- from $ table @Person
+  where_ $ people ^. PersonName ==. val "Robin"
+  pure people
+```
+
+Do this:
+
+```hs
+select $ do
+  people <- from $ table @Person
+  where_ $ people ^. #name ==. val "Robin"
+  pure people
+```
+
+Modules that define Persistent entities should generally not even export their
+fully qualified entity fields e.g. `pattern PersonName`, as there ought to be
+no cause to use them.
+
+## Generate entity record with unprefixed field names
+
+The [`mkPersist`][th] settings should be:
+
+```hs
+sqlSettings {mpsFieldLabelModifier = const id}
+```
+
+This prevents Persistent from prefixing the Haskell record field names,
+in accordance with our Haskell best practices that rely on `NoFieldSelectors`,
+`DuplicateRecordFields`, and `OverloadedRecordDot`.
+
+[th]: https://hackage.haskell.org/package/persistent/docs/Database-Persist-TH.html
+[table]: https://hackage.haskell.org/package/esqueleto-3.6.0.0/docs/Database-Esqueleto-Experimental.html#v:table
+[overloaded-labels]: https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/overloaded_labels.html


### PR DESCRIPTION
Three topics so far in this guide:

- Use type applications in queries (I think we do this in most places)
- Use OverloadedLabels to refer to entity fields (done in curricula and progress)
- Use unqualified record field names (done only in curricula)