### PR TITLE
Recommend enabling ApplicativeDo by default

### DIFF
--- a/haskell-style.md
+++ b/haskell-style.md
@@ -240,6 +240,7 @@ Sort your exports, unless the order matters in your desired Haddock output.
   language: GHC2021
 
   default-extensions:
+    - ApplicativeDo
     - DataKinds
     - DeriveAnyClass
     - DerivingStrategies


### PR DESCRIPTION
See https://github.com/freckle/megarepo/pull/39242 for what this looks like in backend, and some notes in the PR description.

